### PR TITLE
chore: update the change log to release 0.2.0

### DIFF
--- a/dev.tashi.network.transport/CHANGELOG.md
+++ b/dev.tashi.network.transport/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - Unreleased
+## [0.2.0]
 
 ### Added
 
@@ -40,4 +40,5 @@ but it enables people to start using TNT immediately.
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+[0.2.0]: https://github.com/tashigg/tashi-network-transport/releases/tag/v0.2.0
 [0.1.0]: https://github.com/tashigg/tashi-network-transport/releases/tag/v0.1.0

--- a/dev.tashi.network.transport/Runtime/ConsensusEngine/ExternalConnectionManager.cs
+++ b/dev.tashi.network.transport/Runtime/ConsensusEngine/ExternalConnectionManager.cs
@@ -191,7 +191,6 @@ namespace Tashi.ConsensusEngine
             }
             catch (Exception e)
             {
-                Debug.Log("exception in ExternalConnection.Send()");
                 Debug.LogException(e);
                 return;
             }

--- a/dev.tashi.network.transport/Runtime/ConsensusEngine/ExternalConnectionManager.cs
+++ b/dev.tashi.network.transport/Runtime/ConsensusEngine/ExternalConnectionManager.cs
@@ -366,10 +366,9 @@ namespace Tashi.ConsensusEngine
                     PacketLen = (int) packetLen;
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 tce_external_transmit_destroy(ptr);
-                // This is apparently the syntax for re-throwing?
                 throw;
             }
         }

--- a/dev.tashi.network.transport/Runtime/libtashi_consensus_engine.dylib.meta
+++ b/dev.tashi.network.transport/Runtime/libtashi_consensus_engine.dylib.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 1543085912c4f4e969426676b25aa0b5
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dev.tashi.network.transport/Runtime/libtashi_consensus_engine.so.meta
+++ b/dev.tashi.network.transport/Runtime/libtashi_consensus_engine.so.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: e957233ff4c5709f7a7393860fcc20ae
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dev.tashi.network.transport/Runtime/tashi_consensus_engine.dll.meta
+++ b/dev.tashi.network.transport/Runtime/tashi_consensus_engine.dll.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: baaccfa8f9a1ad94c889ff8efaca6641
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
tashi.dev points to examples on the `main` branch which are incompatible with `0.1.0`, so we need to release the latest changes.