### PR TITLE
fix: Ensure GetOperatingSystemFamily is called on the main thread

### DIFF
--- a/dev.tashi.network.transport/Runtime/ConsensusEngine/Platform.cs
+++ b/dev.tashi.network.transport/Runtime/ConsensusEngine/Platform.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 
 namespace Tashi.ConsensusEngine
 {
-    // NOTE: this should match `TceNetworkMode` in TCE or things will get weird.
+    // NOTE: this must match `TceNetworkMode` in TCE or things will get weird.
     public enum NetworkMode
     {
         Loopback,

--- a/dev.tashi.network.transport/Runtime/TashiNetworkTransport.cs
+++ b/dev.tashi.network.transport/Runtime/TashiNetworkTransport.cs
@@ -65,6 +65,11 @@ namespace Tashi.NetworkTransport
             _clientId = publicKey.ClientId;
         }
 
+        private void Awake()
+        {
+            NativeAddressFamily.InitializeStatics(SystemInfo.operatingSystemFamily);
+        }
+
         // Network transport events must be in terms of seconds since the game
         // started, but the Tashi Platform reports times as unix timestamp in
         // nanoseconds.

--- a/dev.tashi.network.transport/Tests/Runtime/ConsensusEngine/SockAddrTests.cs
+++ b/dev.tashi.network.transport/Tests/Runtime/ConsensusEngine/SockAddrTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Net;
+using System.Net.Sockets;
 using Tashi.ConsensusEngine;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace TashiConsensusEngineTests
 {
@@ -19,14 +21,16 @@ namespace TashiConsensusEngineTests
             // Expected value comes first
             Assert.AreEqual(TestClientId, addr.ClientId);
         }
-        
+
         [Test]
         public void TestHashCodeAndEquals()
         {
+            NativeAddressFamily.InitializeStatics(OperatingSystemFamily.Linux);
+
             // These will be two different instances to ensure `Equals` and `GetHashCode` don't use referential equality
             SockAddr addrA = SockAddr.FromClientId(TestClientId);
             SockAddr addrB = SockAddr.FromClientId(TestClientId);
-            
+
             // Expected value comes first
             Assert.AreEqual(addrA.GetHashCode(), addrB.GetHashCode());
             Assert.AreEqual(addrA, addrB);
@@ -40,8 +44,35 @@ namespace TashiConsensusEngineTests
             Assert.IsTrue(IPAddress.TryParse(TestAddrString, out var ipAddr));
 
             IPEndPoint testEndPoint = new IPEndPoint(ipAddr, TestAddrPort);
-            
+
             Assert.AreEqual(testEndPoint, addr.IPEndPoint);
+        }
+
+        [Test]
+        public void TestAddressFamilyParsing_Windows()
+        {
+            NativeAddressFamily.InitializeStatics(OperatingSystemFamily.Windows);
+
+            var actual = NativeAddressFamily.ToAddressFamily(BitConverter.GetBytes((UInt16)23));
+            Assert.AreEqual(AddressFamily.InterNetworkV6, actual);
+        }
+
+        [Test]
+        public void TestAddressFamilyParsing_Linux()
+        {
+            NativeAddressFamily.InitializeStatics(OperatingSystemFamily.Linux);
+
+            var actual = NativeAddressFamily.ToAddressFamily(BitConverter.GetBytes((UInt16)10));
+            Assert.AreEqual(AddressFamily.InterNetworkV6, actual);
+        }
+
+        [Test]
+        public void TestAddressFamilyParsing_Mac()
+        {
+            NativeAddressFamily.InitializeStatics(OperatingSystemFamily.MacOSX);
+
+            var actual = NativeAddressFamily.ToAddressFamily(new byte[] { 0, 30 });
+            Assert.AreEqual( AddressFamily.InterNetworkV6, actual);
         }
     }
 }


### PR DESCRIPTION
It can only be called on the main thread otherwise an exception is thrown.

Fixes TG-197