### PR TITLE
TNT API updates

### DIFF
--- a/Examples/Assets/Scripts/LocalWithLobby.cs
+++ b/Examples/Assets/Scripts/LocalWithLobby.cs
@@ -160,7 +160,7 @@ public class LocalWithLobby : MonoBehaviour
                 }
             }
 
-            if (!NetworkTransport.SessionHasStarted)
+            if (NetworkTransport.SessionState == SessionState.NotStarted)
             {
                 var lobby = await LobbyService.Instance.GetLobbyAsync(_lobbyId);
                 var incomingSessionDetails = IncomingSessionDetails.FromUnityLobby(lobby);
@@ -168,7 +168,16 @@ public class LocalWithLobby : MonoBehaviour
                 // This should be replaced with whatever logic you use to determine when a lobby is locked in.
                 if (incomingSessionDetails.AddressBook.Count == 2)
                 {
-                    NetworkTransport.UpdateSessionDetails(incomingSessionDetails);
+                    NetworkTransport.StartSession(incomingSessionDetails,
+                        () =>
+                        {
+                            Debug.Log("StartSession succeeded");
+                        },
+                        () =>
+                        {
+                            Debug.Log("StartSession failed");
+                        }
+                    );
                 }
             }
         }

--- a/Examples/ProjectSettings/ProjectSettings.asset
+++ b/Examples/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 24
+  serializedVersion: 26
   productGUID: 61b92d0201181d67b84814673e329611
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -42,20 +42,21 @@ PlayerSettings:
   m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
-  defaultScreenWidth: 1920
-  defaultScreenHeight: 1080
+  defaultScreenWidth: 800
+  defaultScreenHeight: 600
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 0
   m_ActiveColorSpace: 0
+  m_SpriteBatchVertexThreshold: 300
   m_MTRendering: 1
   mipStripping: 0
   numberOfMipsStripped: 0
+  numberOfMipsStrippedPerMipmapLimitGroup: {}
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
   iosUseCustomAppBackgroundBehavior: 0
-  iosAllowHTTPDownload: 1
   allowedAutorotateToPortrait: 1
   allowedAutorotateToPortraitUpsideDown: 1
   allowedAutorotateToLandscapeRight: 1
@@ -99,7 +100,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0
@@ -119,8 +120,11 @@ PlayerSettings:
   switchNVNShaderPoolsGranularity: 33554432
   switchNVNDefaultPoolsGranularity: 16777216
   switchNVNOtherPoolsGranularity: 16777216
+  switchGpuScratchPoolGranularity: 2097152
+  switchAllowGpuScratchShrinking: 0
   switchNVNMaxPublicTextureIDCount: 0
   switchNVNMaxPublicSamplerIDCount: 0
+  switchNVNGraphicsFirmwareMemory: 32
   stadiaPresentMode: 0
   stadiaTargetFramerate: 0
   vulkanNumSwapchainBuffers: 3
@@ -128,12 +132,7 @@ PlayerSettings:
   vulkanEnablePreTransform: 0
   vulkanEnableLateAcquireNextImage: 0
   vulkanEnableCommandBufferRecycling: 1
-  m_SupportedAspectRatios:
-    4:3: 1
-    5:4: 1
-    16:10: 1
-    16:9: 1
-    Others: 1
+  loadStoreDebugModeEnabled: 0
   bundleVersion: 1.0
   preloadedAssets: []
   metroInputSource: 0
@@ -147,7 +146,7 @@ PlayerSettings:
   enableFrameTimingStats: 0
   enableOpenGLProfilerGPURecorders: 1
   useHDRDisplay: 0
-  D3DHDRBitDepth: 0
+  hdrBitDepth: 0
   m_ColorGamuts: 00000000
   targetPixelDensity: 30
   resolutionScalingMode: 0
@@ -158,6 +157,7 @@ PlayerSettings:
     Standalone: com.DefaultCompany.2DProject
   buildNumber:
     Standalone: 0
+    VisionOS: 0
     iPhone: 0
     tvOS: 0
   overrideDefaultApplicationIdentifier: 1
@@ -175,12 +175,15 @@ PlayerSettings:
   APKExpansionFiles: 0
   keepLoadedShadersAlive: 0
   StripUnusedMeshComponents: 0
+  strictShaderVariantMatching: 0
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
   iOSTargetOSVersionString: 12.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
   tvOSTargetOSVersionString: 12.0
+  VisionOSSdkVersion: 0
+  VisionOSTargetOSVersionString: 1.0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
@@ -228,8 +231,10 @@ PlayerSettings:
   appleDeveloperTeamID: 
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
+  VisionOSManualSigningProvisioningProfileID: 
   iOSManualSigningProvisioningProfileType: 0
   tvOSManualSigningProvisioningProfileType: 0
+  VisionOSManualSigningProvisioningProfileType: 0
   appleEnableAutomaticSigning: 0
   iOSRequireARKit: 0
   iOSAutomaticallyDetectAndAddCapabilities: 1
@@ -244,6 +249,7 @@ PlayerSettings:
   useCustomLauncherGradleManifest: 0
   useCustomBaseGradleTemplate: 0
   useCustomGradlePropertiesTemplate: 0
+  useCustomGradleSettingsTemplate: 0
   useCustomProguardFile: 0
   AndroidTargetArchitectures: 1
   AndroidTargetDevices: 0
@@ -251,6 +257,7 @@ PlayerSettings:
   androidSplashScreen: {fileID: 0}
   AndroidKeystoreName: 
   AndroidKeyaliasName: 
+  AndroidEnableArmv9SecurityFeatures: 0
   AndroidBuildApkPerCpuArchitecture: 0
   AndroidTVCompatibility: 0
   AndroidIsGame: 1
@@ -264,7 +271,6 @@ PlayerSettings:
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
   chromeosInputEmulation: 1
-  AndroidMinifyWithR8: 0
   AndroidMinifyRelease: 0
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
@@ -412,7 +418,9 @@ PlayerSettings:
     iPhone: 1
     tvOS: 1
   m_BuildTargetGroupLightmapEncodingQuality: []
+  m_BuildTargetGroupHDRCubemapEncodingQuality: []
   m_BuildTargetGroupLightmapSettings: []
+  m_BuildTargetGroupLoadStoreDebugModeSettings: []
   m_BuildTargetNormalMapEncoding: []
   m_BuildTargetDefaultTextureCompressionFormat:
   - m_BuildTarget: Android
@@ -427,6 +435,7 @@ PlayerSettings:
   locationUsageDescription: 
   microphoneUsageDescription: 
   bluetoothUsageDescription: 
+  macOSTargetOSVersion: 10.13.0
   switchNMETAOverride: 
   switchNetLibKey: 
   switchSocketMemoryPoolSize: 6144
@@ -438,6 +447,7 @@ PlayerSettings:
   switchLTOSetting: 0
   switchApplicationID: 0x01004b9000490000
   switchNSODependencies: 
+  switchCompilerFlags: 
   switchTitleNames_0: 
   switchTitleNames_1: 
   switchTitleNames_2: 
@@ -653,6 +663,7 @@ PlayerSettings:
   webGLMemorySize: 32
   webGLExceptionSupport: 1
   webGLNameFilesAsHashes: 0
+  webGLShowDiagnostics: 0
   webGLDataCaching: 1
   webGLDebugSymbols: 0
   webGLEmscriptenArgs: 
@@ -665,12 +676,19 @@ PlayerSettings:
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 0
+  webGLInitialMemorySize: 32
+  webGLMaximumMemorySize: 2048
+  webGLMemoryGrowthMode: 2
+  webGLMemoryLinearGrowthStep: 16
+  webGLMemoryGeometricGrowthStep: 0.2
+  webGLMemoryGeometricGrowthCap: 96
   webGLPowerPreference: 2
   scriptingDefineSymbols: {}
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}
+  il2cppCodeGeneration: {}
   managedStrippingLevel:
     EmbeddedLinux: 1
     GameCoreScarlett: 1
@@ -689,12 +707,9 @@ PlayerSettings:
   suppressCommonWarnings: 1
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
-  enableRoslynAnalyzers: 1
-  selectedPlatform: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 1
-  assemblyVersionValidation: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
@@ -766,13 +781,22 @@ PlayerSettings:
   luminVersion:
     m_VersionCode: 1
     m_VersionName: 
+  hmiPlayerDataPath: 
+  hmiForceSRGBBlit: 1
+  embeddedLinuxEnableGamepadInput: 1
+  hmiLogStartupTiming: 0
+  hmiCpuConfiguration: 
   apiCompatibilityLevel: 6
   activeInputHandler: 0
   windowsGamepadBackendHint: 0
+  cloudProjectId: 
   framebufferDepthMemorylessMode: 0
   qualitySettingsNames: []
+  projectName: 
+  organizationId: 
   cloudEnabled: 0
   legacyClampBlendShapeWeights: 0
-  playerDataPath: 
-  forceSRGBBlit: 1
+  hmiLoadingImage: {fileID: 0}
+  platformRequiresReadableAssets: 0
   virtualTexturingSupportEnabled: 0
+  insecureHttpOption: 0

--- a/dev.tashi.network.transport/CHANGELOG.md
+++ b/dev.tashi.network.transport/CHANGELOG.md
@@ -9,12 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `Platform`'s constructor no longer takes a `syncInterval`, it instead takes
-  `baseMinEventIntervalMicros`. This will be described in detail in the docs.
-  A reasonable default value to start with is 1,500 microseconds. This breaking
-  change is requireddue to a fundamental difference in how the consensus engine
-  decides to synchronize between nodes within the network.
 * Performance has been improved under heavy load.
+
+#### `TashiNetworkTransport` class changes
+* `UpdateSessionDetails` has been renamed to `StartSession` and its
+  documentation has been updated.
+* `OnPlatformInit` has been removed, it shouldn't be necessary for users to know
+  when the lower level `Platform` has been initialized.
+* `SessionHasStarted` has been removed in favour of `SessionState`.
+
+#### `Platform` class changes
+
+`Platform`'s constructor no longer takes a `syncInterval`, it instead takes
+`baseMinEventIntervalMicros`. This will be described in detail in the docs.
+A reasonable default value to start with is 1,500 microseconds. This breaking
+change is required due to a fundamental difference in how the consensus engine
+decides to synchronize between nodes within the network.
 
 ### Fixed
 
@@ -103,6 +113,7 @@ but it enables people to start using TNT immediately.
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 [Discord]: https://discord.com/invite/fPNdgUCGnk
+[0.4.0]: https://github.com/tashigg/tashi-network-transport/releases/tag/v0.4.0
 [0.3.2]: https://github.com/tashigg/tashi-network-transport/releases/tag/v0.3.2
 [0.3.0]: https://github.com/tashigg/tashi-network-transport/releases/tag/v0.3.0
 [0.2.0]: https://github.com/tashigg/tashi-network-transport/releases/tag/v0.2.0

--- a/dev.tashi.network.transport/Runtime/ConsensusEngine/AssemblyInfo.cs
+++ b/dev.tashi.network.transport/Runtime/ConsensusEngine/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("dev.tashi.network.transport.runtimetests")]

--- a/dev.tashi.network.transport/Runtime/ConsensusEngine/AssemblyInfo.cs.meta
+++ b/dev.tashi.network.transport/Runtime/ConsensusEngine/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fea76104300b2c504ac24df1b53fc9c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dev.tashi.network.transport/Runtime/ConsensusEngine/Platform.cs
+++ b/dev.tashi.network.transport/Runtime/ConsensusEngine/Platform.cs
@@ -29,8 +29,6 @@ namespace Tashi.ConsensusEngine
         private bool _started;
         private bool _disposed;
 
-        private ulong _clientId;
-
         // Unity Relay enforces a limit of 1400 bytes per each datagram.
         private static readonly UInt64 MaxRelayDataLen = 1400;
 
@@ -65,8 +63,6 @@ namespace Tashi.ConsensusEngine
         /// </summary>
         public Platform(NetworkMode mode, IPEndPoint bindEndPoint, UInt64 baseMinEventIntervalMicros, SecretKey secretKey)
         {
-            _clientId = secretKey.PublicKey.ClientId;
-
             _platform = tce_init(
                 mode,
                 bindEndPoint.Address.ToString(),

--- a/dev.tashi.network.transport/Runtime/ConsensusEngine/Platform.cs
+++ b/dev.tashi.network.transport/Runtime/ConsensusEngine/Platform.cs
@@ -23,7 +23,7 @@ namespace Tashi.ConsensusEngine
     /// <summary>
     /// The Tashi Platform.
     /// </summary>
-    public class Platform : IDisposable
+    public sealed class Platform : IDisposable
     {
         private IntPtr _platform;
         private bool _started;
@@ -347,7 +347,7 @@ namespace Tashi.ConsensusEngine
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (_disposed)
             {

--- a/dev.tashi.network.transport/Runtime/ConsensusEngine/SockAddr.cs
+++ b/dev.tashi.network.transport/Runtime/ConsensusEngine/SockAddr.cs
@@ -3,11 +3,9 @@ using System.Buffers.Binary;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using UnityEngine;
 using UnityEngine.Assertions;
-using System.Runtime.CompilerServices;
 
 namespace Tashi.ConsensusEngine
 {

--- a/dev.tashi.network.transport/Runtime/TashiNetworkTransport.cs
+++ b/dev.tashi.network.transport/Runtime/TashiNetworkTransport.cs
@@ -360,7 +360,7 @@ namespace Tashi.NetworkTransport
         {
             if (sessionDetails.AddressBook.Count > MaximumSessionSize)
             {
-                throw new Exception($"The maximum supported session size is {MaximumSessionSize}");
+                throw new InvalidOperationException($"The maximum supported session size is {MaximumSessionSize}");
             }
 
             Debug.Log($"Applying incoming session data with {sessionDetails.AddressBook.Count} entries");

--- a/dev.tashi.network.transport/Runtime/TashiNetworkTransport.cs
+++ b/dev.tashi.network.transport/Runtime/TashiNetworkTransport.cs
@@ -14,7 +14,7 @@ using UnityEngine.Assertions;
 namespace Tashi.NetworkTransport
 {
     [AddComponentMenu("Netcode/Tashi Network Transport")]
-    public class TashiNetworkTransport : Unity.Netcode.NetworkTransport
+    public sealed class TashiNetworkTransport : Unity.Netcode.NetworkTransport
     {
         public override ulong ServerClientId { get; }
 


### PR DESCRIPTION
Implements TG-166

This makes various breaking API changes.

* `UpdateSessionDetails` is renamed to `StartSession` to make its functionality clearer. Its behavior depends on the network mode chosen.
* `SessionHasStarted` has been replaced by `SessionState`.
* `OnInitPlatform` has been removed, there should be no reason for users to need to know that `Platform` exists.
* `Platform` and `TashiNetworkTransport` have become sealed.